### PR TITLE
using -> import to safe lock

### DIFF
--- a/src/DopplerSpectroscopyCore.jl
+++ b/src/DopplerSpectroscopyCore.jl
@@ -1,6 +1,6 @@
 module DopplerSpectroscopyCore
 
-using QuadGK
+import QuadGK
 
 
 # documented for more readability of other file's code

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -44,7 +44,7 @@ each of them.
     github page or create an issue)
 """
 function probe(δ::Real, two_level::Quantum2Level, light::LightSource)::Real
-    nₑ, error = quadgk(
+    nₑ, error = QuadGK.quadgk(
         x -> ρₑₑ(x, δ, two_level, light),
         -Inf, +Inf
     )


### PR DESCRIPTION
Using `import` for more stability for future updates of the package.